### PR TITLE
Fix: Removed unnecessary text domain from some placeholders

### DIFF
--- a/widgets/bwdeb-creative-buttons.php
+++ b/widgets/bwdeb-creative-buttons.php
@@ -167,7 +167,7 @@ class BWDEB_CBTNSCreativeButtons extends Widget_Base {
 			[
 				'label' => esc_html__( 'Link', 'bwd-elementor-addons' ),
 				'type' => Controls_Manager::URL,
-				'placeholder' => esc_attr( 'https://www.your-link.com', 'bwd-elementor-addons' ),
+				'placeholder' => esc_attr( 'https://www.your-link.com' ),
 				'default' => [
 					'url' => '#',
 					'is_external' => true,

--- a/widgets/bwdeb-heading.php
+++ b/widgets/bwdeb-heading.php
@@ -120,7 +120,7 @@ class BWDEB_BWDDHHeading extends Widget_Base {
 				'condition' => [
 					'bwddh_heading_title_url_switcher' => 'yes',
 				],
-				'placeholder' => esc_attr( 'https://www.your-link.com', 'bwd-elementor-addons' ),
+				'placeholder' => esc_attr( 'https://www.your-link.com' ),
 				'default' => [
 					'url' => 'https://www.google.com',
 					'is_external' => true,

--- a/widgets/bwdeb-service-flip-box.php
+++ b/widgets/bwdeb-service-flip-box.php
@@ -395,7 +395,7 @@ class BWDEB_BWDServiceFlipBox extends Widget_Base {
 			[
 				'label' => esc_html__( 'Link', 'bwd-elementor-addons' ),
 				'type' => Controls_Manager::URL,
-				'placeholder' => esc_attr( 'https://www.your-link.com', 'bwd-elementor-addons' ),
+				'placeholder' => esc_attr( 'https://www.your-link.com' ),
 				'default' => [
 					'url' => '#',
 					'is_external' => true,

--- a/widgets/dual-button.php
+++ b/widgets/dual-button.php
@@ -154,7 +154,7 @@ class BWDEB_BWDDBDualButtons extends Widget_Base {
 			[
 				'label' => esc_html__( 'Link', 'bwd-elementor-addons' ),
 				'type' => Controls_Manager::URL,
-				'placeholder' => esc_attr( 'https://www.your-link.com', 'bwd-elementor-addons' ),
+				'placeholder' => esc_attr( 'https://www.your-link.com' ),
 				'dynamic' => [
 					'active' => true,
 				],
@@ -393,7 +393,7 @@ class BWDEB_BWDDBDualButtons extends Widget_Base {
 				'dynamic' => [
 					'active' => true,
 				],
-				'placeholder' => esc_attr( 'https://www.your-link.com', 'bwd-elementor-addons' ),
+				'placeholder' => esc_attr( 'https://www.your-link.com' ),
 				'default' => [
 					'url' => 'https://www.google.com',
 					'is_external' => true,


### PR DESCRIPTION
Removed unnecessary text domain from some placeholders

Fix: [These strings are not translated](https://wordpress.org/support/topic/these-strings-are-not-translated/) (partially)